### PR TITLE
Fix crash of laser_assembler if service called before receiving scans

### DIFF
--- a/include/laser_assembler/base_assembler.h
+++ b/include/laser_assembler/base_assembler.h
@@ -295,7 +295,7 @@ bool BaseAssembler<T>::assembleScansInternal(AssembleScans::Request& req, Assemb
     // Blocking period is always in wall-clock time, as it is meant to handle
     // scheduling delays and topic racing, sim time is not appropriate.
     boost::chrono::steady_clock::time_point end_tp = boost::chrono::steady_clock::now() + boost::chrono::nanoseconds(blocking_period.toNSec());
-    while (boost::chrono::steady_clock::now() < end_tp && scan_hist_.rbegin()->header.stamp < req.end)
+    while (boost::chrono::steady_clock::now() < end_tp && (scan_hist_.size() == 0 || scan_hist_.rbegin()->header.stamp < req.end))
     {
       scan_added_cv_.wait_until(scan_hist_lock, end_tp);
     }


### PR DESCRIPTION
Although this is extremely unlikely to hit on an actual robot, this code
would SEGFAULT if the service was called before any scans had been
received.

The code that crashes is a few lines down:
`scan_hist_.rbegin()->header.stamp`.

I ran into this when trying to run the tilt lidar nodes against a bag file.
In that case it is very easy to hit this problem.

This bug does not exist in newer branches of the repo since this code has
been rewritten, therefore this change does not need to be upstreamed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/laser_assembler/1)
<!-- Reviewable:end -->
